### PR TITLE
feat: add ability to provide Tor config

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -103,3 +103,32 @@ jobs:
           netstat -anp | grep :12345
           lsof | grep 12345
         shell: bash
+
+  setup-with-config:
+    name: Setup Tor with a configuration input on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Validate setup-tor
+        uses: ./
+        id: setup-tor-with-config
+        with:
+          config: |
+            ControlPort 9051
+            CookieAuthentication 0
+
+      - name: Verify tor
+        run: __tests__/verify-tor.sh 'emit'
+        shell: bash
+
+      - name: Config was not configured
+        if: ${{ ! contains(steps.setup-tor-with-config.outputs.config-path, 'setup-tor-conf') }}
+        run: |
+          echo "echo "::error::No config path was configured, config path set to: ${{ steps.setup-tor-with-config.outputs.config-path }}"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ steps:
     port: 12345
 ```
 
+Run with a custom configuration file:
+```yaml
+steps:
+- uses: actions/checkout@main
+- uses: tor-actions/setup-tor@main
+  with:
+    config-path: ${{ github.workspace }}/.github/.torrc
+```
+
+Run with a custom configuration:
+```yaml
+steps:
+- uses: actions/checkout@main
+- uses: tor-actions/setup-tor@main
+  with:
+    config: |
+      ControlPort 9051
+      CookieAuthentication 0
+```
+
 ## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,13 @@ inputs:
   token:
     description: Used to pull node distributions from go-versions.  Since there's a default, this is typically not supplied by the user.
     default: ${{ github.token }}
+  config:
+    description: 'A multi-line configuration to use for Tor.'
+  config-path:
+    description: 'A custom `.torrc` configuration file path to use for Tor (will take priority over `config`).'
+outputs:
+  config-path:
+    description: 'The path to the configuration file (if a path or config was provided).'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2584,6 +2584,7 @@ const installer = __importStar(__webpack_require__(749));
 const path_1 = __importDefault(__webpack_require__(622));
 const child_process_1 = __importDefault(__webpack_require__(129));
 const fs_1 = __importDefault(__webpack_require__(747));
+const crypto_1 = __webpack_require__(417);
 const os_1 = __webpack_require__(87);
 const url_1 = __webpack_require__(835);
 function run() {
@@ -2627,7 +2628,9 @@ function run() {
             let configPath = core.getInput('config-path') || undefined;
             let configFlag = [];
             if (configPath || config) {
-                configPath = configPath || `${os_1.tmpdir()}/setup-tor-config`;
+                configPath =
+                    configPath ||
+                        `${os_1.tmpdir()}/setup-tor-conf_${crypto_1.randomBytes(16).toString('hex')}`;
                 if (!fs_1.default.existsSync(configPath)) {
                     fs_1.default.writeFileSync(configPath, config !== null && config !== void 0 ? config : '');
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1005,7 +1005,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const semver = __importStar(__webpack_require__(550));
-const core_1 = __webpack_require__(902);
+const core_1 = __webpack_require__(470);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __webpack_require__(87);
@@ -2583,6 +2583,8 @@ const io = __importStar(__webpack_require__(1));
 const installer = __importStar(__webpack_require__(749));
 const path_1 = __importDefault(__webpack_require__(622));
 const child_process_1 = __importDefault(__webpack_require__(129));
+const fs_1 = __importDefault(__webpack_require__(747));
+const os_1 = __webpack_require__(87);
 const url_1 = __webpack_require__(835);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -2620,14 +2622,28 @@ function run() {
             const torPath = yield io.which('tor');
             const torVersion = (child_process_1.default.execSync(`${torPath} --version`) || '').toString();
             core.info(torVersion);
+            // add configuration
+            const config = core.getInput('config') || undefined;
+            let configPath = core.getInput('config-path') || undefined;
+            let configFlag = [];
+            if (configPath || config) {
+                configPath = configPath || `${os_1.tmpdir()}/setup-tor-config`;
+                if (!fs_1.default.existsSync(configPath)) {
+                    fs_1.default.writeFileSync(configPath, config !== null && config !== void 0 ? config : '');
+                }
+                core.info(`Using Tor configuration at path: ${configPath}`);
+                configFlag = ['-f', configPath];
+                core.setOutput('config-path', configPath);
+            }
             // run tor as daemon program
             const daemon = (core.getInput('daemon') || 'false').toUpperCase() === 'TRUE';
             if (daemon) {
                 const port = core.getInput('port') || '9050';
-                const child = child_process_1.default.spawn(`${torPath}`, ['--SocksPort', `${port}`], {
+                const child = child_process_1.default.spawn(`${torPath}`, ['--SocksPort', `${port}`].concat(configFlag), {
                     detached: true,
                     stdio: 'ignore'
                 });
+                core.info(`Started Tor as daemon with PID: ${child.pid}`);
                 child.unref();
             }
         }
@@ -2752,32 +2768,6 @@ module.exports = function (Yallist) {
 
 /***/ }),
 
-/***/ 398:
-/***/ (function(__unusedmodule, exports) {
-
-"use strict";
-
-// We use any as a valid input type
-/* eslint-disable @typescript-eslint/no-explicit-any */
-Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * Sanitizes an input into a string so it can be passed into issueCommand safely
- * @param input input to sanitize into a string
- */
-function toCommandValue(input) {
-    if (input === null || input === undefined) {
-        return '';
-    }
-    else if (typeof input === 'string' || input instanceof String) {
-        return input;
-    }
-    return JSON.stringify(input);
-}
-exports.toCommandValue = toCommandValue;
-//# sourceMappingURL=utils.js.map
-
-/***/ }),
-
 /***/ 413:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
@@ -2876,42 +2866,6 @@ function escapeProperty(s) {
         .replace(/,/g, '%2C');
 }
 //# sourceMappingURL=command.js.map
-
-/***/ }),
-
-/***/ 445:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-// For internal use, subject to change.
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-// We use any as a valid input type
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__webpack_require__(747));
-const os = __importStar(__webpack_require__(87));
-const utils_1 = __webpack_require__(398);
-function issueCommand(command, message) {
-    const filePath = process.env[`GITHUB_${command}`];
-    if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-    }
-    if (!fs.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-    }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
-        encoding: 'utf8'
-    });
-}
-exports.issueCommand = issueCommand;
-//# sourceMappingURL=file-command.js.map
 
 /***/ }),
 
@@ -3419,7 +3373,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(__webpack_require__(902));
+const core = __importStar(__webpack_require__(470));
 const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const mm = __importStar(__webpack_require__(31));
@@ -7988,92 +7942,6 @@ module.exports = (versions, range, options) => {
 
 /***/ }),
 
-/***/ 888:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const os = __importStar(__webpack_require__(87));
-const utils_1 = __webpack_require__(398);
-/**
- * Commands
- *
- * Command Format:
- *   ::name key=value,key=value::message
- *
- * Examples:
- *   ::warning::This is the message
- *   ::set-env name=MY_VAR::some value
- */
-function issueCommand(command, properties, message) {
-    const cmd = new Command(command, properties, message);
-    process.stdout.write(cmd.toString() + os.EOL);
-}
-exports.issueCommand = issueCommand;
-function issue(name, message = '') {
-    issueCommand(name, {}, message);
-}
-exports.issue = issue;
-const CMD_STRING = '::';
-class Command {
-    constructor(command, properties, message) {
-        if (!command) {
-            command = 'missing.command';
-        }
-        this.command = command;
-        this.properties = properties;
-        this.message = message;
-    }
-    toString() {
-        let cmdStr = CMD_STRING + this.command;
-        if (this.properties && Object.keys(this.properties).length > 0) {
-            cmdStr += ' ';
-            let first = true;
-            for (const key in this.properties) {
-                if (this.properties.hasOwnProperty(key)) {
-                    const val = this.properties[key];
-                    if (val) {
-                        if (first) {
-                            first = false;
-                        }
-                        else {
-                            cmdStr += ',';
-                        }
-                        cmdStr += `${key}=${escapeProperty(val)}`;
-                    }
-                }
-            }
-        }
-        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-        return cmdStr;
-    }
-}
-function escapeData(s) {
-    return utils_1.toCommandValue(s)
-        .replace(/%/g, '%25')
-        .replace(/\r/g, '%0D')
-        .replace(/\n/g, '%0A');
-}
-function escapeProperty(s) {
-    return utils_1.toCommandValue(s)
-        .replace(/%/g, '%25')
-        .replace(/\r/g, '%0D')
-        .replace(/\n/g, '%0A')
-        .replace(/:/g, '%3A')
-        .replace(/,/g, '%2C');
-}
-//# sourceMappingURL=command.js.map
-
-/***/ }),
-
 /***/ 898:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
@@ -8081,251 +7949,6 @@ const compare = __webpack_require__(874)
 const lte = (a, b, loose) => compare(a, b, loose) <= 0
 module.exports = lte
 
-
-/***/ }),
-
-/***/ 902:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const command_1 = __webpack_require__(888);
-const file_command_1 = __webpack_require__(445);
-const utils_1 = __webpack_require__(398);
-const os = __importStar(__webpack_require__(87));
-const path = __importStar(__webpack_require__(622));
-/**
- * The code to exit an action
- */
-var ExitCode;
-(function (ExitCode) {
-    /**
-     * A code indicating that the action was successful
-     */
-    ExitCode[ExitCode["Success"] = 0] = "Success";
-    /**
-     * A code indicating that the action was a failure
-     */
-    ExitCode[ExitCode["Failure"] = 1] = "Failure";
-})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
-//-----------------------------------------------------------------------
-// Variables
-//-----------------------------------------------------------------------
-/**
- * Sets env variable for this action and future actions in the job
- * @param name the name of the variable to set
- * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function exportVariable(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env['GITHUB_ENV'] || '';
-    if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
-    }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
-}
-exports.exportVariable = exportVariable;
-/**
- * Registers a secret which will get masked from logs
- * @param secret value of the secret
- */
-function setSecret(secret) {
-    command_1.issueCommand('add-mask', {}, secret);
-}
-exports.setSecret = setSecret;
-/**
- * Prepends inputPath to the PATH (for this action and future actions)
- * @param inputPath
- */
-function addPath(inputPath) {
-    const filePath = process.env['GITHUB_PATH'] || '';
-    if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
-    }
-    else {
-        command_1.issueCommand('add-path', {}, inputPath);
-    }
-    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
-}
-exports.addPath = addPath;
-/**
- * Gets the value of an input.  The value is also trimmed.
- *
- * @param     name     name of the input to get
- * @param     options  optional. See InputOptions.
- * @returns   string
- */
-function getInput(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
-    if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-}
-exports.getInput = getInput;
-/**
- * Sets the value of an output.
- *
- * @param     name     name of the output to set
- * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function setOutput(name, value) {
-    command_1.issueCommand('set-output', { name }, value);
-}
-exports.setOutput = setOutput;
-/**
- * Enables or disables the echoing of commands into stdout for the rest of the step.
- * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
- *
- */
-function setCommandEcho(enabled) {
-    command_1.issue('echo', enabled ? 'on' : 'off');
-}
-exports.setCommandEcho = setCommandEcho;
-//-----------------------------------------------------------------------
-// Results
-//-----------------------------------------------------------------------
-/**
- * Sets the action status to failed.
- * When the action exits it will be with an exit code of 1
- * @param message add error issue message
- */
-function setFailed(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-}
-exports.setFailed = setFailed;
-//-----------------------------------------------------------------------
-// Logging Commands
-//-----------------------------------------------------------------------
-/**
- * Gets whether Actions Step Debug is on or not
- */
-function isDebug() {
-    return process.env['RUNNER_DEBUG'] === '1';
-}
-exports.isDebug = isDebug;
-/**
- * Writes debug message to user log
- * @param message debug message
- */
-function debug(message) {
-    command_1.issueCommand('debug', {}, message);
-}
-exports.debug = debug;
-/**
- * Adds an error issue
- * @param message error issue message. Errors will be converted to string via toString()
- */
-function error(message) {
-    command_1.issue('error', message instanceof Error ? message.toString() : message);
-}
-exports.error = error;
-/**
- * Adds an warning issue
- * @param message warning issue message. Errors will be converted to string via toString()
- */
-function warning(message) {
-    command_1.issue('warning', message instanceof Error ? message.toString() : message);
-}
-exports.warning = warning;
-/**
- * Writes info to log with console.log.
- * @param message info message
- */
-function info(message) {
-    process.stdout.write(message + os.EOL);
-}
-exports.info = info;
-/**
- * Begin an output group.
- *
- * Output until the next `groupEnd` will be foldable in this group
- *
- * @param name The name of the output group
- */
-function startGroup(name) {
-    command_1.issue('group', name);
-}
-exports.startGroup = startGroup;
-/**
- * End an output group.
- */
-function endGroup() {
-    command_1.issue('endgroup');
-}
-exports.endGroup = endGroup;
-/**
- * Wrap an asynchronous function call in a group.
- *
- * Returns the same type as the function itself.
- *
- * @param name The name of the group
- * @param fn The function to wrap in the group
- */
-function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-        startGroup(name);
-        let result;
-        try {
-            result = yield fn();
-        }
-        finally {
-            endGroup();
-        }
-        return result;
-    });
-}
-exports.group = group;
-//-----------------------------------------------------------------------
-// Wrapper action state
-//-----------------------------------------------------------------------
-/**
- * Saves state for current action, the state can only be retrieved by this action's post job execution.
- *
- * @param     name     name of the state to store
- * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
-}
-exports.saveState = saveState;
-/**
- * Gets the value of an state set by this action's main execution.
- *
- * @param     name     name of the state to get
- * @returns   string
- */
-function getState(name) {
-    return process.env[`STATE_${name}`] || '';
-}
-exports.getState = getState;
-//# sourceMappingURL=core.js.map
 
 /***/ }),
 
@@ -8640,7 +8263,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const core = __importStar(__webpack_require__(902));
+const core = __importStar(__webpack_require__(470));
 /**
  * Internal class for retries
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import * as installer from './installer';
 import path from 'path';
 import cp from 'child_process';
 import fs from 'fs';
+import {randomBytes} from 'crypto';
 import {tmpdir} from 'os';
 import {URL} from 'url';
 
@@ -56,7 +57,9 @@ export async function run(): Promise<void> {
     let configPath = core.getInput('config-path') || undefined;
     let configFlag: Array<string> = [];
     if (configPath || config) {
-      configPath = configPath || `${tmpdir()}/setup-tor-config`;
+      configPath =
+        configPath ||
+        `${tmpdir()}/setup-tor-conf_${randomBytes(16).toString('hex')}`;
       if (!fs.existsSync(configPath)) {
         fs.writeFileSync(configPath, config ?? '');
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,7 +2259,14 @@
   "resolved" "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   "version" "7.0.0"
 
-"is-plain-object@^2.0.3", "is-plain-object@^2.0.4":
+"is-plain-object@^2.0.3":
+  "integrity" "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="
+  "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
+  "version" "2.0.4"
+  dependencies:
+    "isobject" "^3.0.1"
+
+"is-plain-object@^2.0.4":
   "integrity" "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="
   "resolved" "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
   "version" "2.0.4"


### PR DESCRIPTION
This allows either specifying a `config` or `config-path` input in your config. For example:

```yml
- uses: tor-actions/setup-tor@main
  with:
    config: |
      ControlPort 9051
      CookieAuthentication 0
```

Or, alternatively, if you have a Tor configuration file in your repository:

```yml
- uses: tor-actions/setup-tor@main
  with:
    config: /path/to/config/.torrc
```

---

If neither `config` or `config-path` are provided, it will function as before. If `config` is provided, it will be copied into a custom file in your temp directory. Otherwise, `config-path` will take preference over `config`. 👍🏻

The workflow now also returns a `config-path` output, which can be used to set up Tor in a later step with:

```yml
- id: setup-tor
  uses: tor-actions/setup-tor@main
  with:
    config: |
      ControlPort 9051

- run: tor -f '${{ steps.setup-tor.outputs.config-path }}'
```

---

On a side-note, the failing workflow is the Tests one which is failing due to `yarn audit --level=high` returning 44 vulnerabilities. However, that's not related to this change. 👍🏻